### PR TITLE
Change the default border mode: wrap -> replicate

### DIFF
--- a/Deforum_Stable_Diffusion.ipynb
+++ b/Deforum_Stable_Diffusion.ipynb
@@ -909,7 +909,7 @@
         "    rotation_3d_x = \"0:(0)\"#@param {type:\"string\"}\n",
         "    rotation_3d_y = \"0:(0)\"#@param {type:\"string\"}\n",
         "    rotation_3d_z = \"0:(0)\"#@param {type:\"string\"}\n",
-        "    flip_2d_perspective = True #@param {type:\"boolean\"}\n",
+        "    flip_2d_perspective = False #@param {type:\"boolean\"}\n",
         "    perspective_flip_theta = \"0:(0)\"#@param {type:\"string\"}\n",
         "    perspective_flip_phi = \"0:(t%15)\"#@param {type:\"string\"}\n",
         "    perspective_flip_gamma = \"0:(0)\"#@param {type:\"string\"}\n",

--- a/Deforum_Stable_Diffusion.ipynb
+++ b/Deforum_Stable_Diffusion.ipynb
@@ -898,7 +898,7 @@
         "    #@markdown ####**Animation:**\n",
         "    animation_mode = 'None' #@param ['None', '2D', '3D', 'Video Input', 'Interpolation'] {type:'string'}\n",
         "    max_frames = 1000 #@param {type:\"number\"}\n",
-        "    border = 'wrap' #@param ['wrap', 'replicate'] {type:'string'}\n",
+        "    border = 'replicate' #@param ['wrap', 'replicate'] {type:'string'}\n",
         "\n",
         "    #@markdown ####**Motion Parameters:**\n",
         "    angle = \"0:(0)\"#@param {type:\"string\"}\n",

--- a/Deforum_Stable_Diffusion.py
+++ b/Deforum_Stable_Diffusion.py
@@ -865,7 +865,7 @@ def DeforumAnimArgs():
     #@markdown ####**Animation:**
     animation_mode = 'None' #@param ['None', '2D', '3D', 'Video Input', 'Interpolation'] {type:'string'}
     max_frames = 1000 #@param {type:"number"}
-    border = 'wrap' #@param ['wrap', 'replicate'] {type:'string'}
+    border = 'replicate' #@param ['wrap', 'replicate'] {type:'string'}
 
     #@markdown ####**Motion Parameters:**
     angle = "0:(0)"#@param {type:"string"}

--- a/Deforum_Stable_Diffusion.py
+++ b/Deforum_Stable_Diffusion.py
@@ -876,7 +876,7 @@ def DeforumAnimArgs():
     rotation_3d_x = "0:(0)"#@param {type:"string"}
     rotation_3d_y = "0:(0)"#@param {type:"string"}
     rotation_3d_z = "0:(0)"#@param {type:"string"}
-    flip_2d_perspective = True #@param {type:"boolean"}
+    flip_2d_perspective = False #@param {type:"boolean"}
     perspective_flip_theta = "0:(0)"#@param {type:"string"}
     perspective_flip_phi = "0:(t%15)"#@param {type:"string"}
     perspective_flip_gamma = "0:(0)"#@param {type:"string"}


### PR DESCRIPTION
From my experience, the 'replicate' border mode more pleasing when making zoom-out or perspective flip animations as it doesn't create new pictures on the sides and instead extrudes the existing one making softer and less weird transitions diminishing those stripes and lines. The complaint about strange lines and image duplication was one of the first things mentioned under 2d perspective flip Reddit showcase, so this setting is going to be especially visible when the 0.5 features will be released and we need to do it smooth.