### PR TITLE
Add numpngw to pip installs, to allow saving PNG16

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -26,6 +26,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
+    - numpngw>=0.1.2
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .


### PR DESCRIPTION
To be able to save 16-bit per channel depth maps.

Other changes in helpers/depth.py