### PR TITLE
hotfix: set render_steps to false by default

### DIFF
--- a/Deforum_Stable_Diffusion.ipynb
+++ b/Deforum_Stable_Diffusion.ipynb
@@ -1879,7 +1879,7 @@
         "use_manual_settings = False #@param {type:\"boolean\"}\n",
         "image_path = \"/content/drive/MyDrive/AI/StableDiffusion/2022-09/20220903000939_%05d.png\" #@param {type:\"string\"}\n",
         "mp4_path = \"/content/drive/MyDrive/AI/StableDiffu'/content/drive/MyDrive/AI/StableDiffusion/2022-09/sion/2022-09/20220903000939.mp4\" #@param {type:\"string\"}\n",
-        "render_steps = True  #@param {type: 'boolean'}\n",
+        "render_steps = False  #@param {type: 'boolean'}\n",
         "path_name_modifier = \"x0_pred\" #@param [\"x0_pred\",\"x\"]\n",
         "\n",
         "\n",

--- a/Deforum_Stable_Diffusion.py
+++ b/Deforum_Stable_Diffusion.py
@@ -1827,7 +1827,7 @@ fps = 12 #@param {type:"number"}
 use_manual_settings = False #@param {type:"boolean"}
 image_path = "/content/drive/MyDrive/AI/StableDiffusion/2022-09/20220903000939_%05d.png" #@param {type:"string"}
 mp4_path = "/content/drive/MyDrive/AI/StableDiffu'/content/drive/MyDrive/AI/StableDiffusion/2022-09/sion/2022-09/20220903000939.mp4" #@param {type:"string"}
-render_steps = True  #@param {type: 'boolean'}
+render_steps = False  #@param {type: 'boolean'}
 path_name_modifier = "x0_pred" #@param ["x0_pred","x"]
 
 


### PR DESCRIPTION
to prevent 'ValueError: max() arg is an empty sequence' when people are launcing it without rendering substeps (which is to say the default mode)