### PR TITLE
check_is_number func replaced with .isnumeric()

### DIFF
--- a/Deforum_Stable_Diffusion.ipynb
+++ b/Deforum_Stable_Diffusion.ipynb
@@ -1202,7 +1202,7 @@
         "    for i in range(0, max_frames):\n",
         "        if i in key_frames:\n",
         "            value = key_frames[i]\n",
-        "            value_is_number = check_is_number(value)\n",
+        "            value_is_number = value.isnumeric()\n",
         "            # if it's only a number, leave the rest for the default interpolation\n",
         "            if value_is_number:\n",
         "                t = i\n",


### PR DESCRIPTION
was trying to run the notebook and kept getting an error that value_is_number wasn't defined...then I couldn't find where you declared check_is_number as a function anywhere....

ah perhaps I made some initial mistake in the beginning by not running a cell, but....i will say when I changed it to just use .isnumeric() it suddenly worked like a charm