### PR TITLE
Make range for max_frames consistent in replicate

### DIFF
--- a/replicate/replicate.py
+++ b/replicate/replicate.py
@@ -76,7 +76,7 @@ class Predictor(BasePredictor):
     def predict(
         self,
         max_frames: int = Input(
-            description="Number of frames for animation", ge=100, le=1000, default=30
+            description="Number of frames for animation", ge=30, le=1000, default=30
         ),
         animation_prompts: str = Input(
             default="0: a beautiful portrait of a woman by Artgerm, trending on Artstation",


### PR DESCRIPTION
The default value for the number of frames is 30, but the allowable range is from 100 to 1000.
This reduces the minimum to 30 to match the default.

Obviously not a critical change by any means but I was confused for a bit when trying to use this model via replicate.com